### PR TITLE
Preparation for handling debug output

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -3,8 +3,10 @@ package api
 // config holds the server settings. These settings could come from
 // the command-line and/or a configuration file.
 type config struct {
-	Port    int    `json:"port"`    // TCP port number that the server listens on
-	DataDir string `json:"datadir"` // Path to the Cellar data directory
+	Port        int    `json:"port"`         // TCP port number that the server listens on
+	DataDir     string `json:"datadir"`      // Path to the Cellar data directory
+	Verbose     bool   `json:"verbose"`      // Server is verbose
+	VeryVerbose bool   `json:"very_verbose"` // Server is very verbose
 }
 
 func NewConfig() *config {

--- a/cmd/cellard/cellard.go
+++ b/cmd/cellard/cellard.go
@@ -12,6 +12,8 @@ func usage() {
 	fmt.Printf("cellard (dev)\n")
 	fmt.Printf("  --port <num>      %s\n", flag.Lookup("port").Usage)
 	fmt.Printf("  --datadir <path>  %s\n", flag.Lookup("datadir").Usage)
+	fmt.Printf("  -v                %s\n", flag.Lookup("v").Usage)
+	fmt.Printf("  -vv               %s\n", flag.Lookup("vv").Usage)
 	fmt.Printf("  -h, --help        Print this help message\n")
 
 	os.Exit(0)
@@ -26,6 +28,8 @@ func main() {
 
 	flag.IntVar(&config.Port, "port", 8084, "TCP port number to listen on (default: 8084)")
 	flag.StringVar(&config.DataDir, "datadir", ".", "Path to the Cellar data directory")
+	flag.BoolVar(&config.Verbose, "v", false, "Set cellard to be verbose")
+	flag.BoolVar(&config.VeryVerbose, "vv", false, "Set cellard to be very verbose")
 	flag.Parse()
 
 	fmt.Fprintf(os.Stderr, "Starting cellard... listening on port %d\n", config.Port)


### PR DESCRIPTION
Ideally a verbose level setting would be represented as an integer but this turned out to be tricky with the [flag](https://golang.org/pkg/flag/) package. I thought about writing custom code but concluded that it's not worth the time and effort. Moving on.