### PR TITLE
Rename ConfigIndexHandler to IndexConfigHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 [![Cellar Build Status](https://travis-ci.org/tmaesaka/cellar.svg?branch=master)](https://travis-ci.org/tmaesaka/cellar)
 
 Toying with random ideas. Proper content will be added if I see a future in this project.
+
+## Non Trivial Ideas
+
+- Replication for spreading read-workload, resilience and etc
+- Storage Engine layer for custom storage mechanism
+- Proxy mode (or a separate server program) for sharding

--- a/api/handlers/config.go
+++ b/api/handlers/config.go
@@ -8,9 +8,9 @@ import (
 	"github.com/tmaesaka/cellar/config"
 )
 
-// ConfigIndexHandler encodes the current state of the server config to
+// IndexConfigHandler encodes the current state of the server config to
 // JSON and writes the result to the http connection.
-func ConfigIndexHandler(cfg *config.ApiConfig) http.HandlerFunc {
+func IndexConfigHandler(cfg *config.ApiConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// TODO(toru): Write a middleware that does this.
 		w.Header().Set("Content-Type", "application/json")

--- a/api/handlers/config_test.go
+++ b/api/handlers/config_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/tmaesaka/cellar/config"
 )
 
-func TestConfigIndexHandler(t *testing.T) {
+func TestIndexConfigHandler(t *testing.T) {
 	cfg := config.NewApiConfig()
-	handler := ConfigIndexHandler(cfg)
+	handler := IndexConfigHandler(cfg)
 	req, _ := http.NewRequest("GET", "/config", nil)
 
 	recorder := httptest.NewRecorder()

--- a/api/server.go
+++ b/api/server.go
@@ -33,7 +33,7 @@ func Run(config *config.ApiConfig) error {
 	}
 
 	router := vestigo.NewRouter()
-	router.Get("/config", handlers.ConfigIndexHandler(config))
+	router.Get("/config", handlers.IndexConfigHandler(config))
 
 	fmt.Fprintf(os.Stderr, "Starting cellard... listening on port %d\n", config.Port)
 


### PR DESCRIPTION
Using a verb for prefix will contribute to better readability. Especially when there are multiple handlers. Resolves #33